### PR TITLE
Adding support to return non-json data, specifically for pulse tokens

### DIFF
--- a/turbobytes_api.py
+++ b/turbobytes_api.py
@@ -34,12 +34,14 @@ class TurboBytesAPI(object):
         """
         return self.request("GET", path, needs_auth=needs_auth)
 
-    def request(self, method, path, data=None, needs_auth=True):
+    def request(self, method, path, data=None, needs_auth=True, extraHeaders = {}):
         """
         Makes a request to the api
         """
         endpoint = self.server + path
         headers = {}
+        for header,value in extraHeaders.iteritems():
+            headers[header] = value
         if needs_auth:
             headers["X-TB-Timestamp"], headers["Authorization"] = self.generate_auth_headers()
         if method in ["POST", "PUT"]:
@@ -52,7 +54,10 @@ class TurboBytesAPI(object):
             f.close()
             raise Exception(r["status"], r, c)
         else:
-            return json.loads(c)
+            try:
+                return json.loads(c)
+            except ValueError:
+                return c
 
 
     def post(self, path, data, needs_auth=True):


### PR DESCRIPTION
>>> from turbobytes_api import *
>>> tb = TurboBytesAPI(api_key,api_secret)
>>> headers = {}
>>> headers["token"] = tb.get("/api/pulse_token/")
>>> pulse = TurboBytesAPI(api_key,api_secret,"https://pulse.turbobytes.com/api")
>>> pulse.request("POST","/runtest/dns",json.dumps(data),True,headers)
{u'id': u'XXXX'}